### PR TITLE
add init function to Standard Git implementation of Git.Repo

### DIFF
--- a/lib/standard_git.ex
+++ b/lib/standard_git.ex
@@ -16,6 +16,32 @@ defmodule Gitex.Git do
       else: open(Path.dirname(path))
   end
 
+  @std_git_config ~s"""
+  [core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = false
+    logallrefupdates = true
+    ignorecase = true
+    precomposeunicode = true
+  """
+  @doc "Initialize a standard GIT repo : same as `git init PATH` command"
+  def init(path) do
+    git_dir = Path.join(path, ".git")
+    File.mkdir!(git_dir)
+    File.mkdir!(Path.join(git_dir, "branches"))
+    File.mkdir!(Path.join(git_dir, "hooks"))
+    File.mkdir!(Path.join(git_dir, "info"))
+    File.mkdir_p!(Path.join([git_dir, "objects", "info"]))
+    File.mkdir!(Path.join([git_dir, "objects", "pack"]))
+    File.mkdir_p!(Path.join([git_dir, "refs", "heads"]))
+    File.mkdir!(Path.join([git_dir, "refs", "tags"]))
+    File.write!(Path.join(git_dir, "HEAD"), "ref: refs/heads/master")
+    File.touch!(Path.join(git_dir, "description"))
+    File.write!(Path.join(git_dir, "config"), @std_git_config)
+    File.touch!(Path.join([git_dir, "info", "exclude"]))
+  end
+
   defimpl Gitex.Repo, for: Gitex.Git do
     import Bitwise
 

--- a/lib/standard_git.ex
+++ b/lib/standard_git.ex
@@ -25,7 +25,10 @@ defmodule Gitex.Git do
     ignorecase = true
     precomposeunicode = true
   """
-  @doc "Initialize a standard GIT repo : same as `git init PATH` command"
+  @doc """
+    Initialize a standard GIT repo (same as `git init PATH` command)
+    and open that repo.
+    """
   def init(path) do
     git_dir = Path.join(path, ".git")
     File.mkdir!(git_dir)
@@ -40,6 +43,7 @@ defmodule Gitex.Git do
     File.touch!(Path.join(git_dir, "description"))
     File.write!(Path.join(git_dir, "config"), @std_git_config)
     File.touch!(Path.join([git_dir, "info", "exclude"]))
+    open(path)
   end
 
   defimpl Gitex.Repo, for: Gitex.Git do


### PR DESCRIPTION
This basically creates the same files as a `git init` (except for the hooks samples...).

It provides a mean of creating a new repository from scratch without shelling out to command line GIT.
